### PR TITLE
relax puma dependency to version 3.6 or better

### DIFF
--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", "~> 3.6.0"
+  spec.add_runtime_dependency "puma", "~> 3.6"
   spec.add_runtime_dependency "json"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
Thanks for a helpful gem @sj26.

I recently forked it as the basis for a statsd plugin (https://github.com/yob/puma-plugin-statsd) and while doing so noticed this has a fairly strict puma version requirement.

The current version of puma is 3.12 - is there a need to limit this gem to 3.6.x only?