### PR TITLE
Fixed Status class missing accessor for stats and threads

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -120,6 +120,8 @@ Puma::Plugin.create do
 
   # Take puma's stats and construct a sensible status line for Systemd
   class Status
+    attr_reader :stats
+
     def initialize(stats)
       @stats = stats
     end
@@ -130,6 +132,10 @@ Puma::Plugin.create do
 
     def workers
       stats.fetch("workers", 1)
+    end
+
+    def threads
+      stats.fetch("threads", 1)
     end
 
     def booted_workers


### PR DESCRIPTION
Hello,

I found that the plugin is crashing while generating status line:

```
Oct 23 16:51:55 iserver bundle[15024]: [15024] ERROR: ! systemd: notify status failed:
Oct 23 16:51:55 iserver bundle[15024]:   undefined local variable or method `stats' for #<Status:0x00005598ea3460d8>
Oct 23 16:51:55 iserver bundle[15024]: Did you mean?  @stats
Oct 23 16:51:55 iserver bundle[15024]:   /opt/acao_public/backend/shared/vendor/bundle/ruby/2.5.0/gems/puma-plugin-systemd-0.1.2/lib/puma/plugin/systemd.rb:128:in `clustered?'
Oct 23 16:51:55 iserver bundle[15024]:     /opt/acao_public/backend/shared/vendor/bundle/ruby/2.5.0/gems/puma-plugin-systemd-0.1.2/lib/puma/plugin/systemd.rb:156:in `to_s'
[...]
```

This patch seems to work fine on my systems, please give it a look.