### PR TITLE
Make class names more unique to avoid collisions

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -28,7 +28,7 @@ Puma::Plugin.create do
   #
   #   https://www.freedesktop.org/software/systemd/man/sd-daemon.html
   #
-  class Systemd
+  class PumaSystemd
     # Do we have a systemctl binary? This is a good indicator whether systemd
     # is installed at all.
     def present?
@@ -119,7 +119,7 @@ Puma::Plugin.create do
   end
 
   # Take puma's stats and construct a sensible status line for Systemd
-  class Status
+  class PumaSystemdStatus
     def initialize(stats)
       @stats = stats
     end
@@ -178,7 +178,7 @@ Puma::Plugin.create do
 
     # Only install hooks if systemd is present, the systemd is booted by
     # systemd, and systemd has asked us to notify it of events.
-    @systemd = Systemd.new
+    @systemd = PumaSystemd.new
     if @systemd.present? && @systemd.booted? && @systemd.notify?
       @launcher.events.debug "systemd: detected running inside systemd, registering hooks"
       register_hooks
@@ -228,7 +228,7 @@ Puma::Plugin.create do
   end
 
   def status
-    Status.new(fetch_stats)
+    PumaSystemdStatus.new(fetch_stats)
   end
 
   # Update systemd status event second or so


### PR DESCRIPTION
I discovered while trying to use OpenProject with puma-plugin-systemd that the `Systemd` and `Status` classes become globally defined when they are evaluated with `class_eval` as part of `Puma::Plugin.create`. I'm sure there's probably a better way to do this, but here's a quick patch that makes the class names a little less likely to collide (in my case it was the Status class; the Systemd class is probably less likely to be in someone else's code).