### PR TITLE
Fixes #8 - Allow Puma 4.Y

### DIFF
--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", "~> 3.6"
+  spec.add_runtime_dependency "puma", ">= 3.6", "< 5"
   spec.add_runtime_dependency "json"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
Tested as part of [The Foreman](https://github.com/theforeman/foreman) applications use of Puma 4.Y and worked like a charm. Since Puma 5 is in beta, I kept this restricted to less than Puma 5 for now.