### PR TITLE
Add support for Puma 5

### DIFF
--- a/lib/puma/plugin/systemd.rb
+++ b/lib/puma/plugin/systemd.rb
@@ -14,9 +14,10 @@ class Puma::Plugin::Systemd
   Puma::Plugins.register("systemd", self)
 
   # Puma creates the plugin when encountering `plugin` in the config.
-  def initialize(loader)
+  # Puma 5 removed the parameter as it was unused within the plugin
+  def initialize(loader = nil)
     # This is a Puma::PluginLoader
-    @loader = loader
+    @loader = loader if loader
   end
 
   # We can start doing something when we have a launcher:
@@ -85,7 +86,13 @@ class Puma::Plugin::Systemd
   end
 
   def fetch_stats
-    JSON.parse(@launcher.stats)
+    # In Puma < 5, the stats are JSON string
+    # In Puma 5, the stats are already a hash
+    if @launcher.stats.is_a?(String)
+      JSON.parse(@launcher.stats)
+    else
+      @launcher.stats
+    end
   end
 
   def status

--- a/puma-plugin-systemd.gemspec
+++ b/puma-plugin-systemd.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*.rb", "README.md", "LICENSE"]
 
-  spec.add_runtime_dependency "puma", ">= 3.6", "< 5"
+  spec.add_runtime_dependency "puma", ">= 3.6", "< 6"
   spec.add_runtime_dependency "json"
 
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
There is a PR to add native support in Puma 5 (https://github.com/puma/puma/pull/2260) but I think given the difference here, that its worth this plugin supporting Puma 5 to allow existing users to upgrade to Puma 5 instead of having to wait for that PR to resolve and get a release.